### PR TITLE
Removed python update to unsupported version

### DIFF
--- a/docker/bin/container-install-prereqs.sh
+++ b/docker/bin/container-install-prereqs.sh
@@ -29,8 +29,6 @@ apt-get install -qy \
   less \
   lsb-release \
   nano \
-  python3 \
-  python3-pip \
   tzdata \
   unzip \
   vim \


### PR DESCRIPTION
Prevented python from being updated to the latest version instead of staying at the supported 3.8 version.

This was preventing scout from running.
